### PR TITLE
ALV tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ after_script:
 cache:
   directories:
     - deps
+    - plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: elixir
 elixir:
-  - 1.2.3
+  - 1.4.0
 before_script:
   - export PATH=`pwd`/elixir/bin:$PATH
   - mix local.hex --force
   - mix deps.get
-  - mix dialyzer.plt
+  - mix dialyzer --plt
 script:
   - mix dialyzer --halt-exit-status
   - mix test
@@ -15,4 +15,3 @@ after_script:
 cache:
   directories:
     - deps
-    - plt

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,0 +1,5 @@
+Unknown functions:
+Elixir.Exads.DataStructures.BinarySearchTree.Comparable
+Elixir.BST':bst_node
+Unknown types:
+is of type atom() | tuple() not #{}

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -1,6 +1,6 @@
 defmodule Exads.DataStructures.AVLTree do
-
   alias Exads.DataStructures.BinarySearchTree, as: BST
+
 
   defmodule Augmentation do
 
@@ -19,11 +19,13 @@ defmodule Exads.DataStructures.AVLTree do
   """
   @spec new(any) :: BST.Node.bst_node
 
-  def new(value), do: BST.new(value, &augment/1)
+  def new(value), do: BST.new(value, [post: &post_processor/1])
 
   def insert(tree, node_value) do
-    BST.insert(tree, node_value, &augment/1)
+    BST.insert(tree, node_value, [post: &post_processor/1])
   end
+
+  def post_processor(node), do: augment(node)
 
 
   @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -25,7 +25,7 @@ defmodule Exads.DataStructures.AVLTree do
     BST.insert(tree, node_value, [post: &post_processor/1])
   end
 
-  def post_processor(node), do: augment(node)
+  def post_processor(node), do: augment(node) |> balance()
 
 
   @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node
@@ -40,4 +40,30 @@ defmodule Exads.DataStructures.AVLTree do
   defp augment(%BST.Node{left: left, right: right} = node), do:
     %{node | augmentation: %Augmentation{height:  max(left.augmentation.height, right.augmentation.height) + 1,
                                          bf:      left.augmentation.height - right.augmentation.height}}
+
+  defp balance(node) do
+    if Kernel.abs(node.augmentation.bf) > 1 do
+      rotate(node)
+    else
+      node |> augment()
+    end
+  end
+
+  defp rotate(tree) do
+    if (tree.augmentation.bf < -1) do
+      left_rotation(tree)
+    end
+  end
+
+  defp left_rotation(tree) do
+    left = %BST.Node{left: tree.left, right: tree.right.left, value: tree.value} |> augment()
+    right = %BST.Node{left: tree.right.right.left, right: tree.right.right.right, value: tree.right.right.value} |> augment()
+    %BST.Node{left: left, right: right, value: tree.right.value} |> augment()
+  end
+
+  defp calculate_bf(%BST.Node{left: :leaf, right: :leaf}), do: 0
+  defp calculate_bf(%BST.Node{left: :leaf, right: right}), do: Kernel.abs(right.augmentation.bf)
+  defp calculate_bf(%BST.Node{left: left, right: :leaf}), do: left.augmentation.bf
+  defp calculate_bf(%BST.Node{left: left, right: right}), do: Kernel.abs(left.augmentation.bf - right.augmentation.bf)
+
 end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -4,6 +4,10 @@ defmodule Exads.DataStructures.AVLTree do
 
   defmodule Augmentation do
 
+    @moduledoc """
+    AVL augmentation struct for BST required to implement AVL Tree
+    """
+
     @type augmentation :: %__MODULE__{height: integer, bf: integer}
     defstruct height: 0, bf: 0
 
@@ -31,29 +35,29 @@ defmodule Exads.DataStructures.AVLTree do
   end
 
   @spec post_processor(BST.Node.bst_node) :: BST.Node.bst_node
-  defp post_processor(node), do: augment(node) |> balance()
+  defp post_processor(bst_node), do: bst_node |> augment() |> balance()
 
 
   @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node
   defp augment(:leaf), do: :leaf
-  defp augment(%BST.Node{left: :leaf, right: :leaf} = node), do: %{node | augmentation: %Augmentation{}}
-  defp augment(%BST.Node{left: left, right: :leaf} = node) do
-    %{node | augmentation: %Augmentation{height: left.augmentation.height + 1, bf: left.augmentation.height + 1}}
+  defp augment(%BST.Node{left: :leaf, right: :leaf} = bst_node), do: %{bst_node | augmentation: %Augmentation{}}
+  defp augment(%BST.Node{left: left, right: :leaf} = bst_node) do
+    %{bst_node | augmentation: %Augmentation{height: left.augmentation.height + 1, bf: left.augmentation.height + 1}}
   end
-  defp augment(%BST.Node{left: :leaf, right: right} = node) do
-    %{node | augmentation: %Augmentation{height: right.augmentation.height + 1, bf: -1 * right.augmentation.height - 1}}
+  defp augment(%BST.Node{left: :leaf, right: right} = bst_node) do
+    %{bst_node | augmentation: %Augmentation{height: right.augmentation.height + 1, bf: -1 * right.augmentation.height - 1}}
   end
-  defp augment(%BST.Node{left: left, right: right} = node), do:
-    %{node | augmentation: %Augmentation{height:  max(left.augmentation.height, right.augmentation.height) + 1,
-                                         bf:      left.augmentation.height - right.augmentation.height}}
+  defp augment(%BST.Node{left: left, right: right} = bst_node), do:
+    %{bst_node | augmentation: %Augmentation{height:  max(left.augmentation.height, right.augmentation.height) + 1,
+                                             bf:      left.augmentation.height - right.augmentation.height}}
 
 
   @spec balance(BST.Node.bst_node) :: BST.Node.bst_node
-  defp balance(node) do
-    if Kernel.abs(node.augmentation.bf) > 1 do
-      rotate(node)
+  defp balance(bst_node) do
+    if Kernel.abs(bst_node.augmentation.bf) > 1 do
+      rotate(bst_node)
     else
-      node |> augment()
+      bst_node |> augment()
     end
   end
 

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -21,11 +21,13 @@ defmodule Exads.DataStructures.AVLTree do
 
   def new(value), do: BST.new(value, [post: &post_processor/1])
 
+  @spec insert(BST.Node.bst_node, any) :: BST.Node.bst_node
   def insert(tree, node_value) do
     BST.insert(tree, node_value, [post: &post_processor/1])
   end
 
-  def post_processor(node), do: augment(node) |> balance()
+  @spec post_processor(BST.Node.bst_node) :: BST.Node.bst_node
+  defp post_processor(node), do: augment(node) |> balance()
 
 
   @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node
@@ -41,6 +43,8 @@ defmodule Exads.DataStructures.AVLTree do
     %{node | augmentation: %Augmentation{height:  max(left.augmentation.height, right.augmentation.height) + 1,
                                          bf:      left.augmentation.height - right.augmentation.height}}
 
+
+  @spec balance(BST.Node.bst_node) :: BST.Node.bst_node
   defp balance(node) do
     if Kernel.abs(node.augmentation.bf) > 1 do
       rotate(node)
@@ -49,6 +53,7 @@ defmodule Exads.DataStructures.AVLTree do
     end
   end
 
+  @spec rotate(BST.Node.bst_node) :: BST.Node.bst_node
   defp rotate(tree) do
     cond do
       tree.augmentation.bf < -1 ->
@@ -73,12 +78,14 @@ defmodule Exads.DataStructures.AVLTree do
     end
   end
 
+  @spec left_rotation(BST.Node.bst_node) :: BST.Node.bst_node
   defp left_rotation(tree) do
     left = %BST.Node{left: tree.left, right: tree.right.left, value: tree.value} |> augment()
     right = %BST.Node{left: tree.right.right.left, right: tree.right.right.right, value: tree.right.right.value} |> augment()
     %BST.Node{left: left, right: right, value: tree.right.value} |> augment()
   end
 
+  @spec right_rotation(BST.Node.bst_node) :: BST.Node.bst_node
   defp right_rotation(tree) do
     right = %BST.Node{left: tree.left.right, right: tree.right, value: tree.value} |> augment()
     left = %BST.Node{left: tree.left.left.left, right: tree.left.left.right, value: tree.left.left.value} |> augment()

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -53,13 +53,22 @@ defmodule Exads.DataStructures.AVLTree do
     cond do
       tree.augmentation.bf < -1 ->
         tree =
-        if tree.right.augmentation.bf > 0 do
-          %{tree | right: right_rotation(tree.right)} |> augment()
+          if tree.right.augmentation.bf > 0 do
+            %{tree | right: right_rotation(tree.right)} |> augment()
+          else
+            tree
+          end
+        left_rotation(tree)
+
+      tree.augmentation.bf > 1 ->
+      tree =
+        if tree.left.augmentation.bf < 0 do
+          %{tree | left: left_rotation(tree.left)} |> augment()
         else
           tree
         end
-        left_rotation(tree)
-      tree.augmentation.bf > 1 -> right_rotation(tree)
+      right_rotation(tree)
+
       true -> tree |> augment()
     end
   end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -56,26 +56,34 @@ defmodule Exads.DataStructures.AVLTree do
   @spec rotate(BST.Node.bst_node) :: BST.Node.bst_node
   defp rotate(tree) do
     cond do
-      tree.augmentation.bf < -1 ->
-        tree =
-          if tree.right.augmentation.bf > 0 do
-            %{tree | right: right_rotation(tree.right)} |> augment()
-          else
-            tree
-          end
-        left_rotation(tree)
-
-      tree.augmentation.bf > 1 ->
-      tree =
-        if tree.left.augmentation.bf < 0 do
-          %{tree | left: left_rotation(tree.left)} |> augment()
-        else
-          tree
-        end
-      right_rotation(tree)
-
+      tree.augmentation.bf < -1 -> rotate_left_heavy(tree)
+      tree.augmentation.bf > 1 -> rotate_right_heavy(tree)
       true -> tree |> augment()
     end
+  end
+
+  @spec rotate_left_heavy(BST.Node.bst_node) :: BST.Node.bst_node
+  defp rotate_left_heavy(tree) do
+    # Transform to case 1 in case double rotation is required
+    tree =
+      if tree.right.augmentation.bf > 0 do
+        %{tree | right: right_rotation(tree.right)} |> augment()
+      else
+        tree
+      end
+    left_rotation(tree)
+  end
+
+  @spec rotate_right_heavy(BST.Node.bst_node) :: BST.Node.bst_node
+  defp rotate_right_heavy(tree) do
+    # Transform to case 1 in case double rotation is required
+    tree =
+      if tree.left.augmentation.bf < 0 do
+        %{tree | left: left_rotation(tree.left)} |> augment()
+      else
+        tree
+      end
+    right_rotation(tree)
   end
 
   @spec left_rotation(BST.Node.bst_node) :: BST.Node.bst_node

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -34,6 +34,10 @@ defmodule Exads.DataStructures.AVLTree do
     BST.insert(tree, node_value, [post: &post_processor/1])
   end
 
+  def delete_node(tree, node_value) do
+    BST.delete_node(tree, node_value, [post: &post_processor/1])
+  end
+
   @spec post_processor(BST.Node.bst_node) :: BST.Node.bst_node
   defp post_processor(bst_node), do: bst_node |> augment() |> balance()
 
@@ -53,6 +57,7 @@ defmodule Exads.DataStructures.AVLTree do
 
 
   @spec balance(BST.Node.bst_node) :: BST.Node.bst_node
+  defp balance(:leaf), do: :leaf
   defp balance(bst_node) do
     if Kernel.abs(bst_node.augmentation.bf) > 1 do
       rotate(bst_node)

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -42,7 +42,7 @@ defmodule Exads.DataStructures.AVLTree do
   defp post_processor(bst_node), do: bst_node |> augment() |> balance()
 
 
-  @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node
+  @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node | :leaf
   defp augment(:leaf), do: :leaf
   defp augment(%BST.Node{left: :leaf, right: :leaf} = bst_node), do: %{bst_node | augmentation: %Augmentation{}}
   defp augment(%BST.Node{left: left, right: :leaf} = bst_node) do
@@ -56,7 +56,7 @@ defmodule Exads.DataStructures.AVLTree do
                                              bf:      left.augmentation.height - right.augmentation.height}}
 
 
-  @spec balance(BST.Node.bst_node) :: BST.Node.bst_node
+  @spec balance(BST.Node.bst_node | :leaf) :: BST.Node.bst_node | :leaf
   defp balance(:leaf), do: :leaf
   defp balance(bst_node) do
     if Kernel.abs(bst_node.augmentation.bf) > 1 do

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -34,6 +34,10 @@ defmodule Exads.DataStructures.AVLTree do
     BST.insert(tree, node_value, [post: &post_processor/1])
   end
 
+  @doc """
+  Deletes the node with the given node value from the tree
+  """
+
   def delete_node(tree, node_value) do
     BST.delete_node(tree, node_value, [post: &post_processor/1])
   end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -2,6 +2,13 @@ defmodule Exads.DataStructures.AVLTree do
 
   alias Exads.DataStructures.BinarySearchTree, as: BST
 
+  defmodule Augmentation do
+
+    @type augmentation :: %__MODULE__{height: integer, bf: integer}
+    defstruct height: 0, bf: 0
+
+  end
+
 
   @moduledoc """
   An implementation of the AVL Tree abstract data structure
@@ -12,7 +19,23 @@ defmodule Exads.DataStructures.AVLTree do
   """
   @spec new(any) :: BST.Node.bst_node
 
-  def new(value), do: BST.new(value)
+  def new(value), do: BST.new(value, &augment/1)
+
+  def insert(tree, node_value) do
+    BST.insert(tree, node_value, &augment/1)
+  end
 
 
+  @spec augment(BST.Node.bst_node | :leaf) :: BST.Node.bst_node
+  defp augment(:leaf), do: :leaf
+  defp augment(%BST.Node{left: :leaf, right: :leaf} = node), do: %{node | augmentation: %Augmentation{}}
+  defp augment(%BST.Node{left: left, right: :leaf} = node) do
+    %{node | augmentation: %Augmentation{height: left.augmentation.height + 1, bf: left.augmentation.height + 1}}
+  end
+  defp augment(%BST.Node{left: :leaf, right: right} = node) do
+    %{node | augmentation: %Augmentation{height: right.augmentation.height + 1, bf: -1 * right.augmentation.height - 1}}
+  end
+  defp augment(%BST.Node{left: left, right: right} = node), do:
+    %{node | augmentation: %Augmentation{height:  max(left.augmentation.height, right.augmentation.height) + 1,
+                                         bf:      left.augmentation.height - right.augmentation.height}}
 end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -51,7 +51,14 @@ defmodule Exads.DataStructures.AVLTree do
 
   defp rotate(tree) do
     cond do
-      tree.augmentation.bf < -1 -> left_rotation(tree)
+      tree.augmentation.bf < -1 ->
+        tree =
+        if tree.right.augmentation.bf > 0 do
+          %{tree | right: right_rotation(tree.right)} |> augment()
+        else
+          tree
+        end
+        left_rotation(tree)
       tree.augmentation.bf > 1 -> right_rotation(tree)
       true -> tree |> augment()
     end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -1,0 +1,18 @@
+defmodule Exads.DataStructures.AVLTree do
+
+  alias Exads.DataStructures.BinarySearchTree, as: BST
+
+
+  @moduledoc """
+  An implementation of the AVL Tree abstract data structure
+  """
+
+  @doc """
+  Creates a new AVL Tree with the root's value as the given 'value'.
+  """
+  @spec new(any) :: BST.Node.bst_node
+
+  def new(value), do: BST.new(value)
+
+
+end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -50,8 +50,10 @@ defmodule Exads.DataStructures.AVLTree do
   end
 
   defp rotate(tree) do
-    if (tree.augmentation.bf < -1) do
-      left_rotation(tree)
+    cond do
+      tree.augmentation.bf < -1 -> left_rotation(tree)
+      tree.augmentation.bf > 1 -> right_rotation(tree)
+      true -> tree |> augment()
     end
   end
 
@@ -61,9 +63,11 @@ defmodule Exads.DataStructures.AVLTree do
     %BST.Node{left: left, right: right, value: tree.right.value} |> augment()
   end
 
-  defp calculate_bf(%BST.Node{left: :leaf, right: :leaf}), do: 0
-  defp calculate_bf(%BST.Node{left: :leaf, right: right}), do: Kernel.abs(right.augmentation.bf)
-  defp calculate_bf(%BST.Node{left: left, right: :leaf}), do: left.augmentation.bf
-  defp calculate_bf(%BST.Node{left: left, right: right}), do: Kernel.abs(left.augmentation.bf - right.augmentation.bf)
+  defp right_rotation(tree) do
+    right = %BST.Node{left: tree.left.right, right: tree.right, value: tree.value} |> augment()
+    left = %BST.Node{left: tree.left.left.left, right: tree.left.left.right, value: tree.left.left.value} |> augment()
+    %BST.Node{left: left, right: right, value: tree.left.value} |> augment()
+  end
+
 
 end

--- a/lib/data_structures/avl_tree.ex
+++ b/lib/data_structures/avl_tree.ex
@@ -21,6 +21,10 @@ defmodule Exads.DataStructures.AVLTree do
 
   def new(value), do: BST.new(value, [post: &post_processor/1])
 
+  @doc """
+  Creates and inserts a node with its value as 'node_value' into the tree.
+  """
+
   @spec insert(BST.Node.bst_node, any) :: BST.Node.bst_node
   def insert(tree, node_value) do
     BST.insert(tree, node_value, [post: &post_processor/1])

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -103,7 +103,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   Finds the node with the provided 'node_value' or nil if it does not
   exist in the tree.
   """
-  @spec find_node(%{} | :leaf, any) :: %{} | nil
+  @spec find_node(Node.bst_node | :leaf, any) :: Node.bst_node | nil
 
   def find_node(:leaf, _), do: nil
   def find_node(node = %{value: node_value, left: _, right: _},
@@ -122,7 +122,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   @doc """
   Finds the parent of the node with the given 'node_value'.
   """
-  @spec find_parent(%{} | :leaf, any) :: %{} | nil
+  @spec find_parent(Node.bst_node | :leaf, any) :: Node.bst_node | nil
 
   def find_parent(:leaf, _), do: nil
   def find_parent(node, node_value) do

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -1,6 +1,15 @@
 defmodule Exads.DataStructures.BinarySearchTree do
   import Kernel, except: [{:>, 2}, {:<, 2}]
 
+  @moduledoc """
+  An implementation of the Binary Search Tree abstract data structure
+  using Map.
+  """
+
+  @doc """
+  Comparable protocoll which needs to be implemented for all BST values
+  """
+
   defprotocol Comparable do
     @fallback_to_any true
     @dialyzer {:nowarn_function, __protocol__: 1}
@@ -38,12 +47,12 @@ defmodule Exads.DataStructures.BinarySearchTree do
     defstruct value: nil, left: :leaf, right: :leaf, augmentation: nil
   end
 
+  @doc """
+  Implements the identity processor
+  """
+  @spec identity(Node.bst_node) :: Node.bst_node
   def identity(node), do: node
 
-  @moduledoc """
-  An implementation of the Binary Search Tree abstract data structure
-  using Map.
-  """
 
   @doc """
   Creates a new Binary Search Tree with the root's value as the given 'value'.

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -1,7 +1,7 @@
 defmodule Exads.DataStructures.BinarySearchTree do
   import Kernel, except: [{:>, 2}, {:<, 2}]
 
-  defprotocol BSTComparable do
+  defprotocol Comparable do
     @fallback_to_any true
     @dialyzer {:nowarn_function, __protocol__: 1}
 
@@ -19,17 +19,17 @@ defmodule Exads.DataStructures.BinarySearchTree do
 
   end
 
-  defimpl BSTComparable, for: Any do
+  defimpl Comparable, for: Any do
     def left > right, do: Kernel.>(left, right)
     def left < right, do: Kernel.<(left, right)
   end
 
   def left < right do
-    BSTComparable.<(left, right)
+    Comparable.<(left, right)
   end
 
   def left > right do
-    BSTComparable.>(left, right)
+    Comparable.>(left, right)
   end
 
   defmodule Node do

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -1,4 +1,41 @@
 defmodule Exads.DataStructures.BinarySearchTree do
+  import Kernel, except: [{:>, 2}, {:<, 2}]
+
+  defprotocol BSTComparable do
+    @fallback_to_any true
+
+    @doc """
+      Implementation of greater for BST comparisons
+    """
+    @spec greater(any, any) :: boolean
+    def greater(left, right)
+
+    @doc """
+       Implementation of less for BST comparisons
+    """
+    @spec smaller(any, any) :: boolean
+    def smaller(left, right)
+
+  end
+
+  defimpl BSTComparable, for: Any do
+    def greater(left, right), do: Kernel.>(left, right)
+    def smaller(left, right), do: Kernel.<(left, right)
+  end
+
+  def left < right do
+    BSTComparable.smaller(left, right)
+  end
+
+  def left > right do
+    BSTComparable.greater(left, right)
+  end
+
+  defmodule Node do
+
+    @type bst_node :: %__MODULE__{value: any, left: :leaf | bst_node, right: :leaf | bst_node, augmentation: any}
+    defstruct value: nil, left: :leaf, right: :leaf, augmentation: nil
+  end
 
   @moduledoc """
   An implementation of the Binary Search Tree abstract data structure
@@ -8,23 +45,23 @@ defmodule Exads.DataStructures.BinarySearchTree do
   @doc """
   Creates a new Binary Search Tree with the root's value as the given 'value'.
   """
-  @spec new(any) :: %{}
+  @spec new(any) :: Node.bst_node
 
   def new(value) do
-    %{value: value, left: :leaf, right: :leaf}
+    %Node{value: value, left: :leaf, right: :leaf}
   end
 
   @doc """
   Creates and inserts a node with its value as 'node_value' into the tree.
   """
-  @spec insert(%{} | :leaf, any) :: %{}
+  @spec insert(Node.bst_node | :leaf, any) :: Node.bst_node
 
   def insert(:leaf, node_value), do: new node_value
-  def insert(%{value: value, left: left, right: right}, node_value) do
+  def insert(%Node{value: value, left: left, right: right} = current_node, node_value) do
     if node_value < value do
-      %{value: value, left: insert(left, node_value), right: right}
+      %{current_node | left: insert(left, node_value)}
     else
-      %{value: value, left: left, right: insert(right, node_value)}
+      %{current_node | right: insert(right, node_value)}
     end
   end
 

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -69,7 +69,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   Removes a node with 'node_value' from the given 'tree'. Returns :leaf if the
   node does not exist.
   """
-  @spec delete_node(%{}, any) :: %{} | nil
+  @spec delete_node(Node.bst_node, any) :: Node.bst_node | nil
 
   def delete_node(tree, node_value) do
     if exists?(tree, node_value) do
@@ -81,26 +81,22 @@ defmodule Exads.DataStructures.BinarySearchTree do
 
   defp delete(tree, node_value) do
     cond do
-    tree.value == node_value -> del(tree)
-    tree.value <  node_value ->
-    %{left: tree.left,
-      value: tree.value,
-      right: delete(tree.right, node_value)}
+      tree.value == node_value -> del(tree)
+      tree.value <  node_value ->
+        %Node{tree | right: delete(tree.right, node_value)}
       tree.value > node_value ->
-        %{left: delete(tree.left,node_value),
-          value: tree.value,
-          right: tree.right}
+        %Node{tree | left: delete(tree.left,node_value)}
     end
   end
 
-  defp del(%{left: :leaf,  value: _, right: right}), do: right
-  defp del(%{left: left, value: _, right: :leaf}),   do: left
-  defp del(%{left: left, value: _, right: right}) do
-    %{left: left, value: min(right), right: delete(right, min(right))}
+  defp del(%Node{left: :leaf,  value: _, right: right}), do: right
+  defp del(%Node{left: left, value: _, right: :leaf}),   do: left
+  defp del(%Node{left: left, value: _, right: right} = current_node) do
+    %{current_node | value: min(right), right: delete(right, min(right))}
   end
 
-  defp min(%{left: :leaf,  value: val, right: _}), do: val
-  defp min(%{left: left, value: _,   right: _}), do: min left
+  defp min(%Node{left: :leaf,  value: val, right: _}), do: val
+  defp min(%Node{left: left, value: _,   right: _}), do: min left
 
 
   @doc """
@@ -241,14 +237,14 @@ defmodule Exads.DataStructures.BinarySearchTree do
   Returns true if a node with the given 'node_value' exists in the 'tree' or
   false otherwise.
   """
-  @spec exists?(%{}, any) :: boolean
+  @spec exists?(Node.bst_node, any) :: boolean
 
   def exists?(tree, node_value) do
     e tree, node_value
   end
 
   defp e(:leaf, _), do: false
-  defp e(%{value: node_value, left: _, right: _}, node_value), do: true
+  defp e(%Node{value: node_value, left: _, right: _}, node_value), do: true
   defp e(tree_node, node_value) do
     if node_value < tree_node.value do
       e tree_node.left, node_value

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -114,11 +114,13 @@ defmodule Exads.DataStructures.BinarySearchTree do
     cond do
       tree.value == node_value -> del(tree, processors)
       tree.value <  node_value ->
-        delete(tree.right, node_value, processors)
+        tree.right
+          |> delete(node_value, processors)
           |> (fn bst_node -> %Node{tree | right: bst_node} end).()
           |> processors[:post].()
       tree.value > node_value ->
-        delete(tree.left, node_value, processors)
+        tree.left
+          |> delete(node_value, processors)
           |> (fn bst_node -> %Node{tree | left: bst_node} end).()
           |> processors[:post].()
     end
@@ -127,7 +129,9 @@ defmodule Exads.DataStructures.BinarySearchTree do
   defp del(%Node{left: :leaf,  value: _, right: right}, _), do: right
   defp del(%Node{left: left, value: _, right: :leaf}, _),   do: left
   defp del(%Node{left: _, value: _, right: right} = current_node, processors) do
-    %{current_node | value: min(right), right: delete(right, min(right), processors)}
+      current_node
+        |> (fn bst_node -> %{bst_node | value: min(right), right: delete(right, min(right), processors)} end).()
+        |> processors[:post].()
   end
 
   defp min(%Node{left: :leaf,  value: val, right: _}), do: val

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -91,7 +91,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
 
   defp del(%Node{left: :leaf,  value: _, right: right}), do: right
   defp del(%Node{left: left, value: _, right: :leaf}),   do: left
-  defp del(%Node{left: left, value: _, right: right} = current_node) do
+  defp del(%Node{left: _, value: _, right: right} = current_node) do
     %{current_node | value: min(right), right: delete(right, min(right))}
   end
 
@@ -143,7 +143,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   @doc """
   Finds the depth of the node with the given 'node_value'.
   """
-  @spec node_depth(%{} | nil, any) :: integer
+  @spec node_depth(Node.bst_node | nil, any) :: integer
 
   def node_depth(tree, node_value), do: nd tree, node_value, 0
 
@@ -161,7 +161,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   @doc """
   Finds the height of the given 'tree'.
   """
-  @spec tree_height(%{}) :: integer
+  @spec tree_height(Node.bst_node) :: integer
 
   def tree_height(tree) do
     tree
@@ -184,7 +184,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   returned in a list. The order of the search is passed into 'order' using
   the atoms ':in_order', ':pre_order' or ':post_order'
   """
-  @spec depth_first_search(%{}, atom) :: list(any)
+  @spec depth_first_search(BST.bst_node, atom) :: list(any)
 
   def depth_first_search(tree, order) when order == :pre_order or
     order == :in_order  or
@@ -222,7 +222,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   Performs a Breadth-First Search in the given 'tree'. The nodes' values are
   returned as a list.
   """
-  @spec breadth_first_search(%{}) :: nonempty_list(any)
+  @spec breadth_first_search(Node.bst_node) :: nonempty_list(any)
 
   def breadth_first_search(tree) do
     bfs([tree]) |> Enum.map(fn (x) -> x.value end)
@@ -257,7 +257,7 @@ defmodule Exads.DataStructures.BinarySearchTree do
   Returns how many occurrences of the given 'node_value' are inside the
   'tree'.
   """
-  @spec how_many?(%{}, any) :: pos_integer
+  @spec how_many?(Node.bst_node, any) :: pos_integer
 
   def how_many?(tree, node_value) do
     d tree, node_value, 0

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -3,32 +3,33 @@ defmodule Exads.DataStructures.BinarySearchTree do
 
   defprotocol BSTComparable do
     @fallback_to_any true
+    @dialyzer {:nowarn_function, __protocol__: 1}
 
     @doc """
       Implementation of greater for BST comparisons
     """
-    @spec greater(any, any) :: boolean
-    def greater(left, right)
+    @spec any > any :: boolean
+    def left > right
 
     @doc """
        Implementation of less for BST comparisons
     """
-    @spec smaller(any, any) :: boolean
-    def smaller(left, right)
+    @spec any < any :: boolean
+    def left < right
 
   end
 
   defimpl BSTComparable, for: Any do
-    def greater(left, right), do: Kernel.>(left, right)
-    def smaller(left, right), do: Kernel.<(left, right)
+    def left > right, do: Kernel.>(left, right)
+    def left < right, do: Kernel.<(left, right)
   end
 
   def left < right do
-    BSTComparable.smaller(left, right)
+    BSTComparable.<(left, right)
   end
 
   def left > right do
-    BSTComparable.greater(left, right)
+    BSTComparable.>(left, right)
   end
 
   defmodule Node do

--- a/lib/data_structures/binary_tree.ex
+++ b/lib/data_structures/binary_tree.ex
@@ -38,6 +38,9 @@ defmodule Exads.DataStructures.BinarySearchTree do
     defstruct value: nil, left: :leaf, right: :leaf, augmentation: nil
   end
 
+  @spec identityAugment(Node.bst_node) :: Node.bst_node
+  defp identityAugment(node), do: node
+
   @moduledoc """
   An implementation of the Binary Search Tree abstract data structure
   using Map.
@@ -46,23 +49,24 @@ defmodule Exads.DataStructures.BinarySearchTree do
   @doc """
   Creates a new Binary Search Tree with the root's value as the given 'value'.
   """
-  @spec new(any) :: Node.bst_node
+  @spec new(any, (Node.bst_node -> Node.bst_node)) :: Node.bst_node
 
-  def new(value) do
-    %Node{value: value, left: :leaf, right: :leaf}
+  def new(value, augmentation \\ &identityAugment/1) do
+    %Node{value: value, left: :leaf, right: :leaf} |> augmentation.()
   end
 
   @doc """
   Creates and inserts a node with its value as 'node_value' into the tree.
   """
-  @spec insert(Node.bst_node | :leaf, any) :: Node.bst_node
+  @spec insert(Node.bst_node | :leaf, any, (Node.bst_node -> Node.bst_node)) :: Node.bst_node
 
-  def insert(:leaf, node_value), do: new node_value
-  def insert(%Node{value: value, left: left, right: right} = current_node, node_value) do
+  def insert(node, node_value, augmentation \\ &identityAugment/1)
+  def insert(:leaf, node_value, augmentation), do: new(node_value, augmentation)
+  def insert(%Node{value: value, left: left, right: right} = current_node, node_value, augmentation) do
     if node_value < value do
-      %{current_node | left: insert(left, node_value)}
+      %{current_node | left: insert(left, node_value, augmentation)} |> augmentation.()
     else
-      %{current_node | right: insert(right, node_value)}
+      %{current_node | right: insert(right, node_value, augmentation)} |> augmentation.()
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Exads.Mixfile do
 
   # Configuration of the `dialyxir`-package
   def dialyzer do
-    [plt_file: "./plt/.local.plt"]
+    []
   end
 
   # Dependencies can be Hex packages:

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Exads.Mixfile do
 
   # Configuration of the `dialyxir`-package
   def dialyzer do
-    [plt_file: {:no_warn, "./plt/.local.plt"}]
+    [plt_file: {:no_warn, "./plt/.local.plt"}, ignore_warnings: "dialyzer.ignore-warnings"]
   end
 
   # Dependencies can be Hex packages:

--- a/mix.exs
+++ b/mix.exs
@@ -34,11 +34,11 @@ defmodule Exads.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:dialyxir, "~> 0.3.3", only: :dev},
+      {:dialyxir, "~> 0.4", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
       {:earmark, "~> 0.1", only: :dev},
       {:inch_ex, "~> 0.5", only: [:dev, :test]},
-      {:credo, "~> 0.3", only: [:dev, :test]},
+      {:credo, "~> 0.5", only: [:dev, :test]},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "credo": {:hex, :credo, "0.6.0", "44a82f82b94eeb4ba6092c89b8a6730ca1a3291c7940739d5acc8806d25ac991", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "dialyxir": {:hex, :dialyxir, "0.4.3", "a4daeebd0107de10d3bbae2ccb6b8905e69544db1ed5fe9148ad27cd4cb2c0cd", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "inch_ex": {:hex, :inch_ex, "0.5.1", "c1c18966c935944cbb2d273796b36e44fab3c54fd59f906ff026a686205b4e14", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}
+  "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"bunt": {:hex, :bunt, "0.1.5"},
-  "credo": {:hex, :credo, "0.3.3"},
-  "dialyxir": {:hex, :dialyxir, "0.3.3"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "inch_ex": {:hex, :inch_ex, "0.5.1"},
-  "poison": {:hex, :poison, "2.1.0"}}
+%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+  "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.4.1", "236056d6acd25f740f336756c0f3b5dd6e2f0156074bc15f3b779aeee15390c8", [:mix], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "inch_ex": {:hex, :inch_ex, "0.5.1", "c1c18966c935944cbb2d273796b36e44fab3c54fd59f906ff026a686205b4e14", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
+  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -99,6 +99,30 @@ defmodule Exads.DataStructures.AVLTreeTest do
 
   end
 
+  test "right-heavy insert with double rotation required", %{tree: tree} do
+    assert tree |> AVL.insert(14) |> AVL.insert(11) |> AVL.insert(10) ==
+      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        4,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        10,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        6,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                right:        %BST.Node{left:         :leaf,
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        14,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        12,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                value:  11,
+                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+
+  end
+
 
 
 end

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -153,6 +153,73 @@ defmodule Exads.DataStructures.AVLTreeTest do
     end
   end
 
+  describe "delete" do
+
+    test "delete node with a single child and rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(1) |> AVL.delete_node(12) ==
+        %BST.Node{left:         %BST.Node{left:         :leaf,
+                                          right:        :leaf,
+                                          value:        1,
+                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                  right:        %BST.Node{left:         :leaf,
+                                          right:        :leaf,
+                                          value:        6,
+                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                  value: 3,
+                  augmentation: %AVL.Augmentation{height: 1, bf: 0}}
+    end
+
+    test "delete node with left- and right child and rotation required", %{tree: tree} do
+      assert tree
+          |> AVL.insert(2)
+          |> AVL.insert(4)
+          |> AVL.insert(10)
+          |> AVL.insert(18)
+          |> AVL.insert(1)
+          |> AVL.insert(9)
+          |> AVL.insert(16)
+          |> AVL.insert(19)
+          |> AVL.insert(20)
+          |> AVL.delete_node(12)
+        ==
+        %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                                          right:        :leaf,
+                                                                                          value:        1,
+                                                                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                                                  right:    :leaf,
+                                                                  value:    2,
+                                                                  augmentation: %AVL.Augmentation{height: 1, bf: 1}},
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        4,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        3,
+                                          augmentation: %AVL.Augmentation{height: 2, bf: 1}},
+                  right:        %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                                          right:        :leaf,
+                                                                                          value:        9,
+                                                                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                                                  right:        :leaf,
+                                                                  value:        10,
+                                                                  augmentation: %AVL.Augmentation{height: 1, bf: 1}},
+                                          right:        %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                                          right:        :leaf,
+                                                                                          value:        18,
+                                                                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                                                  right:        %BST.Node{left:         :leaf,
+                                                                                          right:        :leaf,
+                                                                                          value:        20,
+                                                                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                                                  value:        19,
+                                                                  augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                                          value:        16,
+                                          augmentation: %AVL.Augmentation{height: 2, bf: 0}},
+                  value: 6,
+                  augmentation: %AVL.Augmentation{height: 3, bf: 0}}
+    end
+
+  end
+
 
 
 end

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -5,7 +5,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
   alias Exads.DataStructures.AVLTree, as: AVL
 
   setup do
-    tree = AVL.new(6) |> AVL.insert(1) |> AVL.insert(12)
+    tree = AVL.new(6) |> AVL.insert(4) |> AVL.insert(12)
     {:ok, %{tree: tree}}
   end
 
@@ -21,7 +21,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
     assert tree |> AVL.insert(14) ==
       %BST.Node{left:         %BST.Node{left:         :leaf,
                                         right:        :leaf,
-                                        value:        1,
+                                        value:        4,
                                         augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                 right:        %BST.Node{left:         :leaf,
                                         right:        %BST.Node{left:         :leaf,
@@ -35,13 +35,13 @@ defmodule Exads.DataStructures.AVLTreeTest do
   end
 
   test "left-heavy insert with no rotation required", %{tree: tree} do
-      assert tree |> AVL.insert(2) ==
+      assert tree |> AVL.insert(5) ==
         %BST.Node{left:         %BST.Node{left:         :leaf,
                                           right:        %BST.Node{left:         :leaf,
                                                                   right:        :leaf,
-                                                                  value:        2,
+                                                                  value:        5,
                                                                   augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                          value:        1,
+                                          value:        4,
                                           augmentation: %AVL.Augmentation{height: 1, bf: -1}},
                   right:        %BST.Node{left:         :leaf,
                                           right:        :leaf,
@@ -55,7 +55,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
     assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
       %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
-                                                                value:        1,
+                                                                value:        4,
                                                                 augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                         right:        %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
@@ -76,25 +76,25 @@ defmodule Exads.DataStructures.AVLTreeTest do
   end
 
   test "left-heavy insert with single rotation required", %{tree: tree} do
-    assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
+    assert tree |> AVL.insert(5) |> AVL.insert(2) |> AVL.insert(1) ==
       %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
                                                                 value:        1,
                                                                 augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        right:        :leaf,
+                                        value:        2,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: 1}},
+                right:        %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        5,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                         right:        %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
-                                                                value:        11,
+                                                                value:        12,
                                                                 augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                         value:        6,
                                         augmentation: %AVL.Augmentation{height: 1, bf: 0}},
-                right:        %BST.Node{left:         :leaf,
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        15,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        14,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
-                value:  12,
+                value:  4,
                 augmentation: %AVL.Augmentation{height: 2, bf: 0}}
 
   end

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -5,7 +5,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
   alias Exads.DataStructures.AVLTree, as: AVL
 
   setup do
-    tree = AVL.new(6) |> AVL.insert(4) |> AVL.insert(12)
+    tree = AVL.new(6) |> AVL.insert(3) |> AVL.insert(12)
     {:ok, %{tree: tree}}
   end
 
@@ -21,7 +21,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
     assert tree |> AVL.insert(14) ==
       %BST.Node{left:         %BST.Node{left:         :leaf,
                                         right:        :leaf,
-                                        value:        4,
+                                        value:        3,
                                         augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                 right:        %BST.Node{left:         :leaf,
                                         right:        %BST.Node{left:         :leaf,
@@ -41,7 +41,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
                                                                   right:        :leaf,
                                                                   value:        5,
                                                                   augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                          value:        4,
+                                          value:        3,
                                           augmentation: %AVL.Augmentation{height: 1, bf: -1}},
                   right:        %BST.Node{left:         :leaf,
                                           right:        :leaf,
@@ -55,7 +55,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
     assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
       %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
-                                                                value:        4,
+                                                                value:        3,
                                                                 augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                         right:        %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
@@ -94,7 +94,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
                                                                 augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                         value:        6,
                                         augmentation: %AVL.Augmentation{height: 1, bf: 0}},
-                value:  4,
+                value:  3,
                 augmentation: %AVL.Augmentation{height: 2, bf: 0}}
 
   end
@@ -103,7 +103,7 @@ defmodule Exads.DataStructures.AVLTreeTest do
     assert tree |> AVL.insert(14) |> AVL.insert(11) |> AVL.insert(10) ==
       %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
-                                                                value:        4,
+                                                                value:        3,
                                                                 augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                         right:        %BST.Node{left:         :leaf,
                                                                 right:        :leaf,
@@ -119,6 +119,30 @@ defmodule Exads.DataStructures.AVLTreeTest do
                                         value:        12,
                                         augmentation: %AVL.Augmentation{height: 1, bf: -1}},
                 value:  11,
+                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+
+  end
+
+  test "left-heavy insert with double rotation required", %{tree: tree} do
+    assert tree |> AVL.insert(2) |> AVL.insert(4) |> AVL.insert(5) ==
+      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        2,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        right:        :leaf,
+                                        value:        3,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: 1}},
+                right:        %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        5,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        12,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        6,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                value:  4,
                 augmentation: %AVL.Augmentation{height: 2, bf: 0}}
 
   end

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -49,7 +49,55 @@ defmodule Exads.DataStructures.AVLTreeTest do
                                           augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                   value:  6,
                   augmentation: %AVL.Augmentation{height: 2, bf: 1}}
-    end
+  end
+
+  test "right-heavy insert with single rotation required", %{tree: tree} do
+    assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
+      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        1,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        11,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        6,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                right:        %BST.Node{left:         :leaf,
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        15,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        14,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                value:  12,
+                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+
+  end
+
+  test "left-heavy insert with single rotation required", %{tree: tree} do
+    assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
+      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        1,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        11,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        6,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                right:        %BST.Node{left:         :leaf,
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        15,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        14,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                value:  12,
+                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+
+  end
 
 
 

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -9,142 +9,148 @@ defmodule Exads.DataStructures.AVLTreeTest do
     {:ok, %{tree: tree}}
   end
 
-  test "new" do
-    assert AVL.new(0) ==
-      %BST.Node{left:         :leaf,
-                right:        :leaf,
-                value:        0,
-                augmentation: %AVL.Augmentation{height: 0, bf: 0}}
+  describe "new" do
+
+    test "new" do
+      assert AVL.new(0) ==
+        %BST.Node{left:         :leaf,
+                  right:        :leaf,
+                  value:        0,
+                  augmentation: %AVL.Augmentation{height: 0, bf: 0}}
+    end
   end
 
-  test "right-heavy insert with no rotation required", %{tree: tree} do
-    assert tree |> AVL.insert(14) ==
-      %BST.Node{left:         %BST.Node{left:         :leaf,
-                                        right:        :leaf,
-                                        value:        3,
-                                        augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                right:        %BST.Node{left:         :leaf,
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        14,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        12,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
-                value:  6,
-                augmentation: %AVL.Augmentation{height: 2, bf: -1}}
-  end
+  describe "insert" do
 
-  test "left-heavy insert with no rotation required", %{tree: tree} do
-      assert tree |> AVL.insert(5) ==
+    test "right-heavy insert with no rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(14) ==
         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                          right:        :leaf,
+                                          value:        3,
+                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                  right:        %BST.Node{left:         :leaf,
                                           right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        14,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        12,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                  value:  6,
+                  augmentation: %AVL.Augmentation{height: 2, bf: -1}}
+    end
+
+    test "left-heavy insert with no rotation required", %{tree: tree} do
+        assert tree |> AVL.insert(5) ==
+          %BST.Node{left:         %BST.Node{left:         :leaf,
+                                            right:        %BST.Node{left:         :leaf,
+                                                                    right:        :leaf,
+                                                                    value:        5,
+                                                                    augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                            value:        3,
+                                            augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                    right:        %BST.Node{left:         :leaf,
+                                            right:        :leaf,
+                                            value:        12,
+                                            augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                    value:  6,
+                    augmentation: %AVL.Augmentation{height: 2, bf: 1}}
+    end
+
+    test "right-heavy insert with single rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
+        %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        3,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        11,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        6,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                  right:        %BST.Node{left:         :leaf,
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        15,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        14,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                  value:  12,
+                  augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+
+    end
+
+    test "left-heavy insert with single rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(5) |> AVL.insert(2) |> AVL.insert(1) ==
+        %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        1,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          right:        :leaf,
+                                          value:        2,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: 1}},
+                  right:        %BST.Node{left:         %BST.Node{left:         :leaf,
                                                                   right:        :leaf,
                                                                   value:        5,
                                                                   augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                          value:        3,
-                                          augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        12,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        6,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                  value:  3,
+                  augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+
+    end
+
+    test "right-heavy insert with double rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(14) |> AVL.insert(11) |> AVL.insert(10) ==
+        %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        3,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        10,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        6,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: 0}},
                   right:        %BST.Node{left:         :leaf,
-                                          right:        :leaf,
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        14,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
                                           value:        12,
-                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                  value:  6,
-                  augmentation: %AVL.Augmentation{height: 2, bf: 1}}
-  end
+                                          augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                  value:  11,
+                  augmentation: %AVL.Augmentation{height: 2, bf: 0}}
 
-  test "right-heavy insert with single rotation required", %{tree: tree} do
-    assert tree |> AVL.insert(11) |> AVL.insert(14) |> AVL.insert(15) ==
-      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        3,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        11,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        6,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
-                right:        %BST.Node{left:         :leaf,
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        15,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        14,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
-                value:  12,
-                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
+    end
 
-  end
+    test "left-heavy insert with double rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(2) |> AVL.insert(4) |> AVL.insert(5) ==
+        %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        2,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          right:        :leaf,
+                                          value:        3,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: 1}},
+                  right:        %BST.Node{left:         %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        5,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        12,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        6,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: 0}},
+                  value:  4,
+                  augmentation: %AVL.Augmentation{height: 2, bf: 0}}
 
-  test "left-heavy insert with single rotation required", %{tree: tree} do
-    assert tree |> AVL.insert(5) |> AVL.insert(2) |> AVL.insert(1) ==
-      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        1,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        right:        :leaf,
-                                        value:        2,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: 1}},
-                right:        %BST.Node{left:         %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        5,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        12,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        6,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
-                value:  3,
-                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
-
-  end
-
-  test "right-heavy insert with double rotation required", %{tree: tree} do
-    assert tree |> AVL.insert(14) |> AVL.insert(11) |> AVL.insert(10) ==
-      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        3,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        10,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        6,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
-                right:        %BST.Node{left:         :leaf,
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        14,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        12,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
-                value:  11,
-                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
-
-  end
-
-  test "left-heavy insert with double rotation required", %{tree: tree} do
-    assert tree |> AVL.insert(2) |> AVL.insert(4) |> AVL.insert(5) ==
-      %BST.Node{left:         %BST.Node{left:         %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        2,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        right:        :leaf,
-                                        value:        3,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: 1}},
-                right:        %BST.Node{left:         %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        5,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        right:        %BST.Node{left:         :leaf,
-                                                                right:        :leaf,
-                                                                value:        12,
-                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
-                                        value:        6,
-                                        augmentation: %AVL.Augmentation{height: 1, bf: 0}},
-                value:  4,
-                augmentation: %AVL.Augmentation{height: 2, bf: 0}}
-
+    end
   end
 
 

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -4,12 +4,52 @@ defmodule Exads.DataStructures.AVLTreeTest do
   alias Exads.DataStructures.BinarySearchTree, as: BST
   alias Exads.DataStructures.AVLTree, as: AVL
 
+  setup do
+    tree = AVL.new(6) |> AVL.insert(1) |> AVL.insert(12)
+    {:ok, %{tree: tree}}
+  end
+
   test "new" do
     assert AVL.new(0) ==
-      %BST.Node{left:   :leaf,
-                right:  :leaf,
-                value:  0}
+      %BST.Node{left:         :leaf,
+                right:        :leaf,
+                value:        0,
+                augmentation: %AVL.Augmentation{height: 0, bf: 0}}
   end
+
+  test "right-heavy insert with no rotation required", %{tree: tree} do
+    assert tree |> AVL.insert(14) ==
+      %BST.Node{left:         %BST.Node{left:         :leaf,
+                                        right:        :leaf,
+                                        value:        1,
+                                        augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                right:        %BST.Node{left:         :leaf,
+                                        right:        %BST.Node{left:         :leaf,
+                                                                right:        :leaf,
+                                                                value:        14,
+                                                                augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                        value:        12,
+                                        augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                value:  6,
+                augmentation: %AVL.Augmentation{height: 2, bf: -1}}
+  end
+
+  test "left-heavy insert with no rotation required", %{tree: tree} do
+      assert tree |> AVL.insert(2) ==
+        %BST.Node{left:         %BST.Node{left:         :leaf,
+                                          right:        %BST.Node{left:         :leaf,
+                                                                  right:        :leaf,
+                                                                  value:        2,
+                                                                  augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                                          value:        1,
+                                          augmentation: %AVL.Augmentation{height: 1, bf: -1}},
+                  right:        %BST.Node{left:         :leaf,
+                                          right:        :leaf,
+                                          value:        12,
+                                          augmentation: %AVL.Augmentation{height: 0, bf: 0}},
+                  value:  6,
+                  augmentation: %AVL.Augmentation{height: 2, bf: 1}}
+    end
 
 
 

--- a/test/avl_tree_test.exs
+++ b/test/avl_tree_test.exs
@@ -1,0 +1,16 @@
+defmodule Exads.DataStructures.AVLTreeTest do
+  use ExUnit.Case, async: true
+
+  alias Exads.DataStructures.BinarySearchTree, as: BST
+  alias Exads.DataStructures.AVLTree, as: AVL
+
+  test "new" do
+    assert AVL.new(0) ==
+      %BST.Node{left:   :leaf,
+                right:  :leaf,
+                value:  0}
+  end
+
+
+
+end

--- a/test/binary_search_tree_test.exs
+++ b/test/binary_search_tree_test.exs
@@ -13,10 +13,10 @@ defmodule BinarySearchTreeTest do
 
   test "insert value in BST rightside", tree do
     assert BST.insert(tree[:tree], 5) ==
-      %{left: %{left: :leaf,
+      %BST.Node{left: %BST.Node{left: :leaf,
                 right: :leaf,
                 value: 1},
-        right: %{left: :leaf,
+        right: %BST.Node{left: :leaf,
                  right: %{left: :leaf,
                           right: :leaf,
                           value: 5 },
@@ -26,12 +26,12 @@ defmodule BinarySearchTreeTest do
 
   test "insert value in BST leftside", tree do
     assert BST.insert(tree[:tree], 0) ==
-      %{left:  %{left:  %{left:  :leaf,
+      %BST.Node{left:  %BST.Node{left:  %BST.Node{left:  :leaf,
                           right: :leaf,
                           value: 0},
                  right: :leaf,
                  value: 1},
-        right: %{left:  :leaf,
+        right: %BST.Node{left:  :leaf,
                  right: :leaf,
                  value: 3},
         value: 2}

--- a/test/binary_search_tree_test.exs
+++ b/test/binary_search_tree_test.exs
@@ -8,7 +8,7 @@ defmodule BinarySearchTreeTest do
   end
 
   test "new BST" do
-    assert BST.new(2) == %{left: :leaf, right: :leaf, value: 2}
+    assert BST.new(2) == %BST.Node{left: :leaf, right: :leaf, value: 2}
   end
 
   test "insert value in BST rightside", tree do
@@ -17,7 +17,7 @@ defmodule BinarySearchTreeTest do
                 right: :leaf,
                 value: 1},
         right: %BST.Node{left: :leaf,
-                 right: %{left: :leaf,
+                 right: %BST.Node{left: :leaf,
                           right: :leaf,
                           value: 5 },
                  value: 3},
@@ -55,7 +55,7 @@ defmodule BinarySearchTreeTest do
       value: 2}
   end
 
-  test "delete existing node right side with left children", tree do
+  test "delete existing node right side with left children" do
     tree = BST.new(6) |> BST.insert(1) |> BST.insert(12) |> BST.insert(8) |> BST.insert(9)
     assert BST.delete_node(tree, 12) ==
     %BST.Node{left:   %BST.Node{left:   :leaf,

--- a/test/binary_search_tree_test.exs
+++ b/test/binary_search_tree_test.exs
@@ -3,6 +3,17 @@ defmodule BinarySearchTreeTest do
   alias Exads.DataStructures.BinarySearchTree, as: BST
   doctest Exads
 
+  defmodule ComplexTestValue do
+    defstruct key: 0, value: ""
+  end
+
+  defimpl BST.BSTComparable, for: ComplexTestValue do
+    import Kernel, except: [{:>, 2}, {:<, 2}]
+
+    def left > right, do: Kernel.>(left.key, right.key)
+    def left < right, do: Kernel.<(left.key, right.key)
+  end
+
   setup do
     {:ok, tree: BST.new(2) |> BST.insert(1) |> BST.insert(3)}
   end
@@ -35,6 +46,16 @@ defmodule BinarySearchTreeTest do
                  right: :leaf,
                  value: 3},
         value: 2}
+  end
+
+  test "insert complex value in BST" do
+    assert BST.new(%ComplexTestValue{key: 6}) |> BST.insert(%ComplexTestValue{key: 1}) ==
+      %BST.Node{left:   %BST.Node{left:    :leaf,
+                                 right:   :leaf,
+                                 value:   %ComplexTestValue{key: 1}},
+                right:  :leaf,
+                value:  %ComplexTestValue{key: 6}}
+
   end
 
   test "delete existing node in BST rightside", tree do

--- a/test/binary_search_tree_test.exs
+++ b/test/binary_search_tree_test.exs
@@ -39,7 +39,7 @@ defmodule BinarySearchTreeTest do
 
   test "delete existing node in BST rightside", tree do
     assert BST.delete_node(tree[:tree], 3) ==
-      %{left:  %{left:  :leaf,
+      %BST.Node{left:  %BST.Node{left:  :leaf,
                 right: :leaf,
                 value: 1},
         right: :leaf,
@@ -48,8 +48,8 @@ defmodule BinarySearchTreeTest do
 
   test "delete existing node in BST leftside", tree do
     assert BST.delete_node(tree[:tree], 1) ==
-    %{left:  :leaf,
-      right: %{left:  :leaf,
+    %BST.Node{left:  :leaf,
+      right: %BST.Node{left:  :leaf,
                right: :leaf,
                value: 3},
       value: 2}
@@ -58,11 +58,11 @@ defmodule BinarySearchTreeTest do
   test "delete existing node right side with left children", tree do
     tree = BST.new(6) |> BST.insert(1) |> BST.insert(12) |> BST.insert(8) |> BST.insert(9)
     assert BST.delete_node(tree, 12) ==
-    %{left:   %{left:   :leaf,
+    %BST.Node{left:   %BST.Node{left:   :leaf,
                 right:  :leaf,
                 value:  1},
-      right:  %{left:   :leaf,
-                right:  %{left:   :leaf,
+      right:  %BST.Node{left:   :leaf,
+                right:  %BST.Node{left:   :leaf,
                           right:  :leaf,
                           value:  9},
                 value:  8},
@@ -75,7 +75,7 @@ defmodule BinarySearchTreeTest do
 
   test "find existing node", tree do
     assert BST.find_node(tree[:tree], 3) ==
-      %{left: :leaf, right: :leaf, value: 3}
+      %BST.Node{left: :leaf, right: :leaf, value: 3}
   end
 
   test "find non-existing node", tree do

--- a/test/binary_search_tree_test.exs
+++ b/test/binary_search_tree_test.exs
@@ -7,7 +7,7 @@ defmodule BinarySearchTreeTest do
     defstruct key: 0, value: ""
   end
 
-  defimpl BST.BSTComparable, for: ComplexTestValue do
+  defimpl BST.Comparable, for: ComplexTestValue do
     import Kernel, except: [{:>, 2}, {:<, 2}]
 
     def left > right, do: Kernel.>(left.key, right.key)

--- a/test/binary_search_tree_test.exs
+++ b/test/binary_search_tree_test.exs
@@ -84,10 +84,10 @@ defmodule BinarySearchTreeTest do
 
   test "find existing node's parent", tree do
     assert BST.find_parent(tree[:tree], 3) ==
-      %{left:  %{left:  :leaf,
+      %BST.Node{left:  %BST.Node{left:  :leaf,
                 right: :leaf,
                 value: 1},
-        right: %{left:  :leaf,
+        right: %BST.Node{left:  :leaf,
                 right: :leaf,
                 value: 3},
         value: 2}


### PR DESCRIPTION
# AVL Tree
As discussed the separate PR for the AVL Tree implementation/suggestion. I've made some changes to BST tree implementation as well as added the AVL tree which "sits" on top of the BST.
Since the changes in the BST affect its general structure I'd love to to get some feedback.  
The follwing gives a high level description about the changes. I think the details are best discussed at the specific code lines...

As mentioned please regard the current implementation as suggestion/```MVP``` and basis for further improvements/extensions

## General
As already hinted at in the intro the AVL tree leverages the already existing BST (which in my opinion kind of makes sense since lots of operation can be reused).  
For the AVL tree to work some changes were required in the BST:

1. Struct for BST nodes
2. Comparable protocol for complex node values
3. Hooks for the new, insert and delete operation

## BST Node
The bst nodes consist of:  

* value: Does now accept any kind of value types (like structs, ints...)
* left: Left child
* right: Right child
* augmentation: This is to allow the BST to be used as base for other kind of tree structures (like AVL or Red-Black trees ;)). The idea is to use that field as means for storing required tree strcuture values (e.g. the AVL stores the balance factor as well as the height as separate struct in that field). The field is set during the various tree operations (like insert, delete...). To keep it focused only tree structure values should be stored there. Augmentations belonging to the stored value itself belong into the struct stored in the value field.

The idea regaring the augmentation is/was somehow related to the general procedure for augmenting datastructures (as for example described in [CLRS Chapter 14 3rd edition](https://mitpress.mit.edu/books/introduction-algorithms)).

## Comparable protocol
For the BST to work with any kind of data structure as value (e.g. structs as well as "simple" types a BST Comparable protocol was introduced that the value types stored in the BST are required to implement (as described in this [google discussion](https://groups.google.com/forum/#!topic/elixir-lang-talk/-1-pBQCPZuQ) there doesn't seem to be a "generic" comparable protocol which can be implemented).  
The BST already contains an implementation/fallback for the ```Any``` type (falling back to Kernel).

## Hook methods
To avoid traversing the complete tree again for adding the AVL augmentations (```balance factor``` and ```height```) some kind of hooks were required to directly perform these calculations during BST ```new```, ```insert``` and ```delete```.  
These have been named ```processors``` and currently the BST supports a pre- and post processor.  

* The pre processor is performed before the tree operation on the BST node (the ```new``` operation does not support that operation since the node does not yet exist)
* The post processor is executed after the tree operation on the BST node (and is supported by all operations changing the tree structure)

For the pre- as well as the postprocessor a standard identity processor is executed in case nothing is provided.

I made some thoughts whether to use a dedicated module or function keyword list. I decided for the latter as it somehow seems to be the elixir approach (but as I'm kind of new to elixir I could also be mistaken regaring that).

## AVL Tree
The AVL tree implementation leverages the described BST extensions for performing the required operations.

### Augmentation
It introduces an augmentation struct:

* height: Stores the height of the node in the tree staring a zero (for leaf nodes)
* bf: balance factor of the node which must be <= 1 for the AVL tree to be balanced. It is calculated ```left.height - right.height``` (however the ordering makes now difference)

### Postprocessor
A postprocess is added which performs the required rotations as well as node augmentations.

* augmentation: Calculates the augmentation values
* rotation: Performs the required rotations depending on whether the tree is left, right, left-right or right-left heavy

After every rotation the augmentation values are "updated".
The summarized steps are:  

1. Perform the standard BST operation (like insert or delete)
2. For all nodes on the path to the node (implicitly done by the BST operation)
	1. Check if the node is balanced
	2. Rotate if required
	3. Augment

Although in the case of insert it would be sufficient to just check the parant of the newly inserted node, the immutable character of elixir/erlang required all nodes on the path from the root to the affected node to be traversed.

## Tests
Tests for the BST updates as well as the AVL tree operations have been added.  
The test dedicated to the AVL tree should cover the different rotation cases (please let me know in case I've missed cases).

# Other
I had some trouble to get the dialyzer going through. It seems that it has issues with structs as well as protocols. Therefore a ```dialyzer.ignore-warnings``` file has been added to get a green build again ;). I'd love to hear if someone knows how to avoid these warnings.  
I've found a [elixir talk](https://groups.google.com/forum/#!topic/elixir-lang-talk/nnYgjeSGcrs) regarding that issue and it looks like this is somehow a bug. However the talk is from 2014 so maybe there have been some changes regarding that.  
Also worth mentioning is that I do not get the issue on my local machine, it just appears during the travis build.  

The displayed credo issue is just a warning regarding the ```@spec``` definition for the greater- and less implementations for the ```Comparable``` protocol.  

In case I have missed anything else please let me know ;)